### PR TITLE
Added openSUSE TW base image

### DIFF
--- a/100.rootfs-opensuse-tumbleweed/Dockerfile
+++ b/100.rootfs-opensuse-tumbleweed/Dockerfile
@@ -1,0 +1,138 @@
+# syntax=docker/dockerfile:1
+ARG OPENSUSE_VERSION=latest
+
+FROM opensuse/tumbleweed:${OPENSUSE_VERSION}
+
+ARG ARKADE_BIN_DIR
+ARG BTOP_VERSION
+ARG CFSSL_VERSION
+ARG LAB_USER
+ARG WEBSOCAT_VERSION
+
+# udev is needed for booting a "real" VM, setting up the ttyS0 console properly
+# kmod is needed for modprobing modules
+RUN <<EOF
+set -eu
+
+zypper ref -s
+zypper dup -y
+
+# rpm.install.excludedocs is set to true on the official TW image
+
+zypper -n in --no-recommends \
+  awk \
+  bash-completion \
+  bind-utils \
+  bzip2 \
+  ca-certificates \
+  curl \
+  dbus-1 \
+  file \
+  gettext \
+  git \
+  gnupg \
+  htop \
+  iproute \
+  iptables \
+  iptables-nft \
+  iputils \
+  kmod \
+  lsb-release \
+  lsof \
+  make \
+  man \
+  man-pages \
+  mtr \
+  netcat \
+  net-tools \
+  nftables \
+  psmisc \
+  procps \
+  ripgrep \
+  rng-tools \
+  socat \
+  sudo \
+  system-group-wheel \
+  systemd \
+  traceroute \
+  tree \
+  udev \
+  unzip \
+  vim \
+  wget
+
+zypper -n clean
+
+# Unsure if this is needed, copied from the Fedora image
+systemctl mask networkd-dispatcher.service
+
+rm -f /.dockerenv
+
+# Create the following files, but unset them.
+# Unsure if this is needed as the TW image contains both files and they are empty by default
+echo "" > /etc/machine-id && mkdir -p /var/lib/dbus/ && echo "" > /var/lib/dbus/machine-id
+
+echo "root:root" | chpasswd
+EOF
+
+RUN <<EOF
+set -eu
+
+zypper ref -s
+zypper -n in --no-recommends openssh-server
+
+echo "HostKey /etc/ssh/ssh_host_ed25519_key" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "AuthenticationMethods publickey" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "PasswordAuthentication no" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "KbdInteractiveAuthentication no" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "PrintLastLog no" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "AddressFamily inet" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "UseDNS no" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "MaxAuthTries 5" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "MaxSessions 10" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+echo "MaxStartups 10:30:100" >> /etc/ssh/sshd_config.d/iximiuz-playground.conf
+
+systemctl mask sshd-keygen@.service
+systemctl mask sshd-keygen.target
+systemctl enable sshd
+
+rm -f /etc/ssh/ssh_host_*
+EOF
+
+RUN systemctl mask systemd-network-generator.service
+
+
+COPY examiner* /usr/local/bin
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/set-up-systemd-examiner-service.sh
+
+
+# System-wide user tools.
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-arkade.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-common-tools.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-btop.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-cfssl.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-websocat.sh
+RUN curl https://fx.wtf/install.sh | sh
+
+
+# User-specific tools - root
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-fzf.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-bashrc.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-git.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-vimrc.sh
+
+
+# Add the lab user.
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/add-lab-user.sh
+
+USER $LAB_USER
+ENV HOME=/home/$LAB_USER
+
+COPY 100.rootfs-opensuse-tumbleweed/welcome $HOME/.welcome
+
+# User-specific tools - $LAB_USER
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-code-server.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/get-fzf.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-bashrc.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts USER=$LAB_USER /tmp/scripts/customize-git.sh
+RUN --mount=type=bind,source=scripts,target=/tmp/scripts /tmp/scripts/customize-vimrc.sh

--- a/100.rootfs-opensuse-tumbleweed/welcome
+++ b/100.rootfs-opensuse-tumbleweed/welcome
@@ -1,0 +1,19 @@
+Welcome to iximiuz Labs' openSUSE Tumbleweed Linux Playground! 🚀
+
+This is a refined openSUSE Tumbleweed Linux VM, curated with tools for
+efficient learning and hands-on experimenting:
+
+- vim, fzf, ripgrep: Command-line file editing and searching.
+- fx, jq, yq: Powerful JSON and YAML viewers and processors.
+- curl, socat, websocat: A comprehensive networking toolkit.
+- arkade: An efficient installer for additional tools you might require.
+
+Additional services at your disposal:
+
+- Port publishing: Showcase your app with its own public URL.
+- Terminal sharing: Collaborate seamlessly by sharing your terminal session.
+- registry.iximiuz.com: A private hub to push and pull container images.
+
+Playground VMs are ephemeral and short-lived — terminating a VM purges
+all data, including images in the private registry. Please, do not use
+playgrounds for processing critical or sensitive information.

--- a/README.md
+++ b/README.md
@@ -40,29 +40,30 @@ make base-3xx  # Development environments
 
 ### Base Operating Systems (100-series)
 
-| Image | Description |
-|-------|-------------|
-| `almalinux` | AlmaLinux-based environment |
-| `alpine` | Lightweight Alpine Linux |
-| `archlinux` | Arch Linux with typical sysadmin tools |
-| `debian-stable` | Debian stable release with typical sysadmin tools |
-| `debian-testing` | Debian testing release with typical sysadmin tools |
-| `fedora` | Latest Fedora release with typical sysadmin tools |
-| `kali-linux` | Kali Linux for security testing with typical sysadmin tools |
-| `rockylinux` | Rocky Linux enterprise environment with typical sysadmin tools |
-| `ubuntu-22-04` | Ubuntu 22.04 LTS with typical sysadmin tools |
-| `ubuntu-24-04` | Ubuntu 24.04 LTS with typical sysadmin tools |
+| Image                 | Description                                                    |
+| --------------------- | -------------------------------------------------------------- |
+| `almalinux`           | AlmaLinux-based environment                                    |
+| `alpine`              | Lightweight Alpine Linux                                       |
+| `archlinux`           | Arch Linux with typical sysadmin tools                         |
+| `debian-stable`       | Debian stable release with typical sysadmin tools              |
+| `debian-testing`      | Debian testing release with typical sysadmin tools             |
+| `fedora`              | Latest Fedora release with typical sysadmin tools              |
+| `kali-linux`          | Kali Linux for security testing with typical sysadmin tools    |
+| `opensuse-tumbleweed` | Latest openSUSE tumbleweed with typical sysadmin tools         |
+| `rockylinux`          | Rocky Linux enterprise environment with typical sysadmin tools |
+| `ubuntu-22-04`        | Ubuntu 22.04 LTS with typical sysadmin tools                   |
+| `ubuntu-24-04`        | Ubuntu 24.04 LTS with typical sysadmin tools                   |
 
 ### Container Runtimes (200-series)
 
-| Image | Description |
-|-------|-------------|
-| `incus` | Incus container/VM manager |
-| `nerdctl` | containerd-native Docker-compatible CLI |
-| `podman` | Podman rootless containers |
-| `ubuntu-docker` | Ubuntu with Docker engine |
-| `ubuntu-k0s` | k0s Kubernetes distribution |
-| `ubuntu-k3s-bare` | k3s minimal setup |
+| Image             | Description                             |
+| ----------------- | --------------------------------------- |
+| `incus`           | Incus container/VM manager              |
+| `nerdctl`         | containerd-native Docker-compatible CLI |
+| `podman`          | Podman rootless containers              |
+| `ubuntu-docker`   | Ubuntu with Docker engine               |
+| `ubuntu-k0s`      | k0s Kubernetes distribution             |
+| `ubuntu-k3s-bare` | k3s minimal setup                       |
 
 ### Miscellaneous images (300-series and 400-series)
 

--- a/scripts/add-lab-user.sh
+++ b/scripts/add-lab-user.sh
@@ -7,7 +7,7 @@ PASSWORD="${LAB_USER}"
 
 if [ -f /etc/almalinux-release ] || [ -f /etc/fedora-release ] || [ -f /etc/rocky-release ]; then
     adduser --comment "" --uid "$USER_ID" "$USERNAME"
-elif [ -f /etc/arch-release ]; then
+elif [ -f /etc/arch-release ] || [ -f /etc/products.d/openSUSE.prod ]; then
     useradd -m -c "" -u "$USER_ID" "$USERNAME"
 else
     adduser --disabled-password --gecos "" --uid "$USER_ID" "$USERNAME"
@@ -25,6 +25,8 @@ elif [ -f /etc/arch-release ]; then
 elif [ -f /etc/fedora-release ]; then
     SUDO_GROUP="wheel"
 elif [ -f /etc/rocky-release ]; then
+    SUDO_GROUP="wheel"
+elif [ -f /etc/products.d/openSUSE.prod ]; then
     SUDO_GROUP="wheel"
 fi
 


### PR DESCRIPTION
Adds openSUSE tumbleweed to the list of base images.

Tested with the following playground yaml:

```
kind: playground
playground:
  machines:
    - name: opensuse-01
      drives:
        - source: oci://ghcr.io/e-minguez/iximiuz-labs-playgrounds:opensuse-tw-latest
          mount: /
      network:
        interfaces:
          - network: local
      resources:
        cpuCount: 2
        ramSize: 4G
```