### PR TITLE
fix: misconfigured podman for laborant user + missing packages

### DIFF
--- a/200.rootfs-podman/Dockerfile
+++ b/200.rootfs-podman/Dockerfile
@@ -11,9 +11,12 @@ USER root
 RUN <<EOF
 set -eu
 
+setcap cap_setuid+ep /usr/bin/newuidmap
+setcap cap_setgid+ep /usr/bin/newgidmap
+
 # TODO: install buildah - for some reason it started making the VM hang since 5.10.199
 dnf install -y \
-  podman
+  podman podman-compose fuse-overlayfs
 EOF
 
 RUN podman completion bash > /etc/bash_completion.d/podman


### PR DESCRIPTION
Fixes #4 

by adding missing packages:

- podman-compose
- fuse-overlayfs

proper capabilities for required tools for rootless subuid/subguid setups